### PR TITLE
support juttle >= 0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ addons:
         - g++-4.8
 
 before_install:
-  - export CXX="g++-4.8"
+    - export CXX="g++-4.8"
+    - npm install juttle@^0.2.0
 
 node_js:
     - '4.2'
     - '5.0'
 
 before_script:
-    - npm install juttle@^0.1.0
     - npm install -g jshint
     - npm install -g jscs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 before_install:
     - export CXX="g++-4.8"
-    - npm install juttle@^0.2.0
+    - npm install juttle@^0.2.0 juttle-sql-adapter-common@^0.2.0
 
 node_js:
     - '4.2'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "juttle-sqlite-adapter",
   "version": "0.1.0",
   "description": "Juttle adapter for SQLite",
-  "keywords": ["juttle", "adapter", "sqlite"],
+  "keywords": [
+    "juttle",
+    "adapter",
+    "sqlite"
+  ],
   "homepage": "https://github.com/juttle/juttle-sqlite-adapter",
   "bugs": "https://github.com/juttle/juttle-sqlite-adapter/issues",
   "license": "Apache-2.0",
@@ -14,7 +18,8 @@
     "lint": "npm run jshint && npm run style"
   },
   "dependencies": {
-    "juttle-sql-adapter-common": "^0.1.0",
+    "juttle": "^0.2.0",
+    "juttle-sql-adapter-common": "^0.2.0",
     "knex": "^0.9.0",
     "sqlite3": "^3.1.1",
     "underscore": "^1.8.3"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "npm run jshint && npm run style"
   },
   "dependencies": {
-    "juttle": "^0.2.0",
+    "juttle": ">=0.2.0",
     "juttle-sql-adapter-common": "^0.2.0",
     "knex": "^0.9.0",
     "sqlite3": "^3.1.1",


### PR DESCRIPTION
Bump the juttle-sql-adapter-common dependency to ^0.2.0.
Relax the juttle dependency to >=0.2.0.

Update the travis scripts to explicitly install all the right versions to make the tests pass with node_modules cached.

Relates to https://github.com/juttle/juttle/issues/145
Relates to https://github.com/juttle/outrigger/issues/48